### PR TITLE
Fix null tags error on pages with no tags

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -26,7 +26,7 @@ const SEO = ({title, tags, description}) => {
     <Helmet title={seo.title}>
       <meta name="description" content={seo.description}/>
       <meta name="image" content={seo.image}/>
-      {tags.length > 0 && <meta property="keywords" content={tags.join(", ")}/> }
+      {tags && tags.length > 0 && <meta property="keywords" content={tags.join(", ")}/> }
 
       {seo.url && <meta property="og:url" content={seo.url}/>}
       {seo.title && <meta property="og:title" content={seo.title}/>}


### PR DESCRIPTION
For pages without tags to load for SEO, an error would appear as it is
attempting to access the property .length of a null object, doing a
basic null safety check before this fixes it