### PR TITLE
Fix responsive design

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,9 +6,9 @@ import ThemeToggle from "../components/theme-toggle"
 
 export default () => (
   <div className={indexStyles.homeContainer}>
+    <ThemeToggle style={{position: `absolute`, right: 0, top: 0, margin: `15px`}}/>
     <SEO title="Home"/>
     <div className={indexStyles.mainContainer}>
-      <ThemeToggle style={{position: `absolute`, right: 0, top: 0, margin: `15px`}}/>
       <h1>Hi!<span role="img" aria-label="wave"> 👋 </span>I am Woo Jia Hao!</h1>
       <p>
         I go by the moniker of Chill online. I am a software developer from the tiny red dot - Singapore! I recently

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,5 +1,5 @@
 .home-container {
-  height: 100vh;
+  height: 100%;
   margin: 0 auto;
   max-width: 700px;
   display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -147,6 +147,15 @@ pre[class*="language-"] {
   p {
     line-height: 20px;
   }
+
+  blockquote {
+    width: 90%;
+    margin: 0 auto 2em;
+  }
+
+  blockquote::before {
+    width: 5px;
+  }
 }
 
 @media screen and (max-width: 512px) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,12 +16,8 @@ h1, h2, h3, h4, h5, h6 {
   fill: var(--fg-color);
 }
 
-body, #___gatsby {
-  overflow-y: hidden;
-}
-
-html {
-  overflow-y: auto;
+body, html, #___gatsby, #gatsby-focus-wrapper {
+  height: 100%;
 }
 
 body {


### PR DESCRIPTION
- Fix homepage being cut off in shorter screen sizes by setting the height of the parents to `100%`
- Add responsiveness to `<blockquote></blockquote>` by shrinking the elements to fit on the page